### PR TITLE
Workaround Object.freeze() for JSI hosted object.

### DIFF
--- a/patches/workaround_jsi_object_freeze.patch
+++ b/patches/workaround_jsi_object_freeze.patch
@@ -1,0 +1,48 @@
+diff --git a/src/objects/js-objects.cc b/src/objects/js-objects.cc
+index 3666f5a..d17dba4 100644
+--- a/src/objects/js-objects.cc
++++ b/src/objects/js-objects.cc
+@@ -3815,24 +3815,25 @@ Maybe<bool> JSObject::PreventExtensionsWithTransition(
+         PrototypeIterator::GetCurrent<JSObject>(iter), should_throw);
+   }
+
+-  if (object->map().has_named_interceptor() ||
+-      object->map().has_indexed_interceptor()) {
+-    MessageTemplate message = MessageTemplate::kNone;
+-    switch (attrs) {
+-      case NONE:
+-        message = MessageTemplate::kCannotPreventExt;
+-        break;
+-
+-      case SEALED:
+-        message = MessageTemplate::kCannotSeal;
+-        break;
+-
+-      case FROZEN:
+-        message = MessageTemplate::kCannotFreeze;
+-        break;
+-    }
+-    RETURN_FAILURE(isolate, should_throw, NewTypeError(message));
+-  }
++  // Workaround Object.freeze() for JSI hosted object - https://github.com/Kudo/react-native-v8/issues/27
++  // if (object->map().has_named_interceptor() ||
++  //     object->map().has_indexed_interceptor()) {
++  //   MessageTemplate message = MessageTemplate::kNone;
++  //   switch (attrs) {
++  //     case NONE:
++  //       message = MessageTemplate::kCannotPreventExt;
++  //       break;
++  //
++  //     case SEALED:
++  //       message = MessageTemplate::kCannotSeal;
++  //       break;
++  //
++  //     case FROZEN:
++  //       message = MessageTemplate::kCannotFreeze;
++  //       break;
++  //   }
++  //   RETURN_FAILURE(isolate, should_throw, NewTypeError(message));
++  // }
+
+   Handle<Symbol> transition_marker;
+   if (attrs == NONE) {

--- a/scripts/patch.sh
+++ b/scripts/patch.sh
@@ -7,11 +7,17 @@ source $(dirname $0)/env.sh
 V8_PATCHSET_ANDROID=(
   # V8 shared library support
   "v8_shared_library.patch"
+
+  # https://github.com/Kudo/react-native-v8/issues/27
+  "workaround_jsi_object_freeze.patch"
 )
 
 V8_PATCHSET_IOS=(
   # V8 shared library support
   "v8_shared_library_ios.patch"
+
+  # https://github.com/Kudo/react-native-v8/issues/27
+  "workaround_jsi_object_freeze.patch"
 )
 
 ######################################################################################


### PR DESCRIPTION
Although https://github.com/facebook/react-native/pull/27013 should be the correct solution to fix https://github.com/Kudo/react-native-v8/issues/27, considering the PR has no progress for a while, I should have some alternatives.
Moreover, even the PR being merged, old RN such as 0.59 or 0.60 may not include the fixes.
That is why here to have the workaround and patch V8 internally which removing the Object.freeze() w/ interceptors check.