### PR TITLE
support a variant without external startup data

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,6 +14,10 @@ jobs:
     strategy:
       matrix:
         variant: [intl, nointl, jit-intl, jit-nointl]
+        external-startup-data: ['snapshot']
+        include:
+          - variant: jit-nointl
+            external-startup-data: 'nosnapshot'
 
     container:
       image: kudo/ubuntu-nonroot:20.04
@@ -22,6 +26,7 @@ jobs:
         TZ: UTC
         NO_INTL: ${{ contains(matrix.variant, 'nointl') }}
         NO_JIT: ${{ !contains(matrix.variant, 'jit') }}
+        EXTERNAL_STARTUP_DATA: ${{ matrix.external-startup-data == 'snapshot' }}
         DEPOT_TOOLS_UPDATE: 0
 
     steps:
@@ -80,7 +85,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: dist-${{ matrix.variant }}
+          name: dist-${{ matrix.variant }}-${{ matrix.external-startup-data }}
           path: dist.tar
 
 

--- a/packages/v8-android-jit-nointl-nosnapshot/package.json
+++ b/packages/v8-android-jit-nointl-nosnapshot/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "v8-android-jit-nointl-nosnapshot",
+  "version": "11.1000.4",
+  "description": "Pre-build version of V8 to be used by React Native apps",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Kudo/v8-android-buildscripts.git",
+    "directory": "packages/v8-android-jit-nointl-nosnapshot"
+  },
+  "keywords": [
+    "react-native",
+    "android",
+    "v8"
+  ],
+  "license": "BSD-2-Clause",
+  "bugs": {
+    "url": "https://github.com/Kudo/v8-android-buildscripts/issues"
+  },
+  "homepage": "https://github.com/Kudo/v8-android-buildscripts#readme",
+  "files": [
+    "dist/**/*"
+  ]
+}

--- a/scripts/archive.sh
+++ b/scripts/archive.sh
@@ -9,15 +9,18 @@ function makeDistPackageDir() {
 
   local jit_suffix=""
   local intl_suffix=""
+  local extra_suffix=""
   if [[ ${NO_JIT} != "true" ]]; then
     jit_suffix="-jit"
   fi
-
   if [[ ${NO_INTL} = "true" ]]; then
     intl_suffix="-nointl"
   fi
+  if [[ ${PLATFORM} = "android" && ${EXTERNAL_STARTUP_DATA} = "false" ]]; then
+    extra_suffix="-nosnapshot"
+  fi
 
-  echo "${DIST_DIR}/packages/v8-${PLATFORM}${jit_suffix}${intl_suffix}"
+  echo "${DIST_DIR}/packages/v8-${PLATFORM}${jit_suffix}${intl_suffix}${extra_suffix}"
 }
 
 DIST_PACKAGE_DIR=$(makeDistPackageDir)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -113,11 +113,11 @@ function buildArch()
 
   local output_dir=''
   if [[ ${PLATFORM} = "ios" ]]; then
-    echo "Build v8 ${ios_env} ${arch} variant NO_INTL=${NO_INTL}"
+    echo "Build v8 ${ios_env} ${arch} variant NO_INTL=${NO_INTL} EXTERNAL_STARTUP_DATA=${EXTERNAL_STARTUP_DATA}"
     output_dir="out.v8.ios.${ios_env}.${arch}"
     gn gen --args="${GN_ARGS_BASE} ${GN_ARGS_BUILD_TYPE} target_cpu=\"${arch}\" target_environment=\"${ios_env}\"" "${output_dir}"
   else
-    echo "Build v8 ${arch} variant NO_INTL=${NO_INTL} NO_JIT=${NO_JIT}"
+    echo "Build v8 ${arch} variant NO_INTL=${NO_INTL} NO_JIT=${NO_JIT} EXTERNAL_STARTUP_DATA=${EXTERNAL_STARTUP_DATA}"
     output_dir="out.v8.${arch}"
     gn gen --args="${GN_ARGS_BASE} ${GN_ARGS_BUILD_TYPE} target_cpu=\"${arch}\"" "${output_dir}"
   fi

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -48,9 +48,13 @@ IOS_DEPLOYMENT_TARGET="12.0"
 export PATH="$DEPOT_TOOLS_DIR:$PATH"
 PLATFORM=$(verify_platform $1)
 
-if [[ ${PLATFORM} = "android" ]]; then
-  EXTERNAL_STARTUP_DATA="true"
-else
-  EXTERNAL_STARTUP_DATA="false"
+if [[ -z ${EXTERNAL_STARTUP_DATA} ]]; then
+  if [[ ${PLATFORM} = "android" ]]; then
+    EXTERNAL_STARTUP_DATA="true"
+  else
+    EXTERNAL_STARTUP_DATA="false"
+  fi
+fi
+if [[ -z ${NO_JIT} && ${PLATFORM} = "ios" ]]; then
   NO_JIT="true"
 fi

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -7,10 +7,11 @@ import sys
 
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 PACKAGE_MAP = {
-    "v8-android": "dist-intl.zip",
-    "v8-android-nointl": "dist-nointl.zip",
-    "v8-android-jit": "dist-jit-intl.zip",
-    "v8-android-jit-nointl": "dist-jit-nointl.zip",
+    "v8-android": "dist-intl-snapshot.zip",
+    "v8-android-nointl": "dist-nointl-snapshot.zip",
+    "v8-android-jit": "dist-jit-intl-snapshot.zip",
+    "v8-android-jit-nointl": "dist-jit-nointl-snapshot.zip",
+    "v8-android-jit-nointl-nosnapshot": "dist-jit-nointl-nosnapshot.zip",
 }
 
 MACOS_TOOLS_DIST_MAP = {


### PR DESCRIPTION
# Why

fixes #38

# How

introduce a new `v8-android-jit-nointl-nosnapshot` variant